### PR TITLE
Change the code of merknadstype from M619 to M084

### DIFF
--- a/version1/03 - Code lists.md
+++ b/version1/03 - Code lists.md
@@ -220,7 +220,7 @@ No default values are present in this list and must be configured in the system 
 
 No default values are present in this list and must be configured in the system before use.
 
-### merknadstype (M619)
+### merknadstype (M084)
 
 | Code | Name                  | Comment |
 |:-----|:----------------------|:--------|


### PR DESCRIPTION
Merknadstype was incorrectly using the avskrivningsmaate code from the
metadatakatalog.