### PR TITLE
Add a public variant format

### DIFF
--- a/version1/03 - Code lists.md
+++ b/version1/03 - Code lists.md
@@ -160,7 +160,8 @@ No default values are present in this list and must be configured in the system 
 | Code | Name              | Comment |
 |:-----|:------------------|:--------|
 | P    | Produksjonsformat |         |
-| A    | Arkivformat       | &nbsp;  |
+| A    | Arkivformat       |         |
+| O    | Offentlig         | &nbsp;  |
 
 ### skjerming (M500)
 


### PR DESCRIPTION
Will be used to identify public versions of documents in the Archive. A public version of a document is an additional variant of a document in addition to the production and archival versions/variants. Typically, the public version will be based on the latest archival version of a document. A public version of a document will typically contain redacted text and there might be pages omitted.